### PR TITLE
Allow to get estimated params as variables

### DIFF
--- a/hillfit/fitting.py
+++ b/hillfit/fitting.py
@@ -44,6 +44,7 @@ class HillFit(object):
     ) -> None:
         self.x_data = x_data
         self.y_data = y_data
+        self.params = Params(0, 0, 0, 0)
 
     def _equation(self, x, *params):
         """
@@ -54,7 +55,7 @@ class HillFit(object):
         )
         return hilleq
 
-    def _get_param(self) -> Params:
+    def _get_params(self) -> None:
         """
         Use ``scipy.optimize.curve_fit()`` to estimate parameters.
         """
@@ -74,8 +75,7 @@ class HillFit(object):
             p0=param_initial,
             bounds=param_bounds,
         )
-        params = Params(*popt)
-        return params
+        self.params = Params(*popt)
 
     def fitting(self, num: int = 1000, show_popt: bool = True) -> Tuple[np.ndarray, np.ndarray]:
         """
@@ -114,9 +114,9 @@ class HillFit(object):
         >>> plt.legend()
         >>> plt.show()
         """
-        popt = self._get_param()
+        self._get_params()
         if show_popt:
-            print(popt)
+            print(self.params)
         x_fit = np.logspace(np.log10(self.x_data[0]), np.log10(self.x_data[-1]), num)
-        y_fit = self._equation(x_fit, *popt)
+        y_fit = self._equation(x_fit, *self.params)
         return x_fit, y_fit

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -1,3 +1,5 @@
+from math import fabs
+
 import numpy as np
 from hillfit import HillFit
 
@@ -19,6 +21,9 @@ def test_plot():
     ]
     model = HillFit(x_data, y_data)
     x_fit, y_fit = model.fitting()
+
+    assert fabs(model.params.EC50 - 12.94410262619117) < 1e-3
+
     assert np.allclose(
         x_fit,
         [


### PR DESCRIPTION
```python
>>> from hillfit import HillFit
>>> x_data = [
...   9.210, 10.210, 10.580, 10.830, 11.080,
...   11.330, 11.580, 11.830, 12.080, 12.330,
...   12.580, 12.830, 13.080, 13.330, 13.580,
...   13.830, 14.080, 14.330, 14.580, 14.830,
...   15.080, 15.330, 15.580, 15.830, 17.580
... ]
>>> y_data = [
...    0.000, 0.000, 0.000, 1.667, 2.222,
...    5.682, 9.524, 15.315, 16.000, 31.183,
...    39.000, 47.222, 47.475, 63.208, 77.143,
...    75.214, 80.612, 92.784, 94.167, 93.137,
...    95.902, 96.396, 97.872, 98.246, 100.000
... ]
>>> model = HillFit(x_data, y_data)
>>> x_fit, y_fit = model.fitting()
>>> model.params.EC50
12.94410262619117
```